### PR TITLE
refactor(app) : AppProps 임포트 코드 추가

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,23 +1,23 @@
 import { Inter } from 'next/font/google';
+import type { AppProps } from 'next/app'
 import AppLayout from 'components/common/AppLayout';
 import Globals from 'styles/Globals';
 
 const inter = Inter({ subsets: ['latin'] });
+ 
 
-type AppProps = {
-  Component: React.ElementType;
-}; 
-
-function App({ Component }: AppProps) {
+const App = ({ Component, pageProps }: AppProps) => {
   return (
     <main className={inter.className}>
       <AppLayout>
-        <Component />
+        <Component {...pageProps}/>
         <Globals />
       </AppLayout>
+     
     </main>
-  );
+  )
 }
+
  
 export default App;
 


### PR DESCRIPTION

type AppProps = {

   Component: React.ElementType;
   };
import type { AppProps } from 'next/app';

Next.js 프레임워크에서 제공하는 타입인AppProps import 시켰습니다.